### PR TITLE
Fixed a race condition

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -147,6 +147,7 @@ Scanner.prototype._onData = function(packet) {
 
 Scanner.prototype._ready = function() {
   this.isReady = true
+  this.isWaiting = false
   this.device.flush()
   this.device.removeAllListeners()
   this.device.on('data', this._onData.bind(this))


### PR DESCRIPTION
On the Pi version of the SwipeStation hardware, if the scanner is waiting for a response during a periodic reset the system locks up. This change prevents that by resetting the flag that says the system is waiting for a response.